### PR TITLE
fix: Remove typed properties incompatible with PHP version

### DIFF
--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -56,7 +56,7 @@ class QueryHandler
     /**
      * @var array<string>
      */
-    private array $includeAggregations = [];
+    private $includeAggregations = [];
 
     /**
      * @var array

--- a/src/Request/VariantMinimumQuantity.php
+++ b/src/Request/VariantMinimumQuantity.php
@@ -6,7 +6,8 @@ use Medialeads\Apiv3Client\Common\RequestElementInterface;
 
 class VariantMinimumQuantity implements RequestElementInterface
 {
-    private int $quantity;
+    /** @var int */
+    private $quantity;
 
     public function __construct(int $quantity)
     {


### PR DESCRIPTION
The minimum PHP version is set to 7.1 and typed properties are introduce
 in 7.4

Close 10744 10745 10857